### PR TITLE
Fix invalid call to alternate constructor in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Getting Started
 ```python 
 from taskc.simple import TaskdConnection
 tc = TaskdConnection()
-tc.from_taskrc() # only works if you have taskwarrior setup
+tc = TaskdConnection.from_taskrc() # only works if you have taskwarrior setup
 tc.connect()
 resp = tc.pull()
 ```


### PR DESCRIPTION
Since `from_taskrc()` is designed as an alternate constructor, it should be called from the class, receiving an instance as a return value.
