### PR TITLE
Using taskd-client-py without taskrc

### DIFF
--- a/taskc/simple.py
+++ b/taskc/simple.py
@@ -13,10 +13,8 @@ logger = logging.getLogger(__name__)
 
 class TaskdConnection(object):
 
-    def __init__(self, port=53589):
-        self.port = port
-        self.cacert_file = False
-        self.cacert = False
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
 
     def manage_connection(f):
         def conn_wrapper(self, *args, **kwargs):


### PR DESCRIPTION
Hello,

Actually only **port** could be changed on-the-fly (without taskrc parsing).

It will be useful to avoid `~/.taskrc` parsing, if not needed.